### PR TITLE
Add WhatsApp and paybutton to product page

### DIFF
--- a/productos-xoloitzcuintle/index.html
+++ b/productos-xoloitzcuintle/index.html
@@ -18,12 +18,16 @@
     .producto p { font-size: 16px; margin: 0 0 12px; }
     .boton { display: inline-block; background: #c20003; color: white; padding: 10px 20px; border-radius: 8px; text-decoration: none; font-weight: bold; }
     .boton:hover { background: #900002; }
+    .whatsapp { background: #25D366; margin-top: 8px; }
+    .whatsapp:hover { background: #1da851; }
+    .paybutton-widget { margin-top: 10px; }
   </style>
 </head>
 <body>
   <header>
     <h1>Productos Naturales para tu Xoloitzcuintle</h1>
     <p>Creados por Xolos Ramírez. Compra directa desde XolosArmy Network.</p>
+    <p><strong>Envíos por Correos de México o DHL con costo extra.</strong></p>
   </header>
 
   <section class="productos">
@@ -32,29 +36,38 @@
       <h2>Bálsamo de Árbol de Té</h2>
       <p>Regenera y calma la piel del Xoloitzcuintle. 100% natural.</p>
       <a class="boton" href="https://xolosarmy.xyz/productos">Comprar en XolosArmy</a>
+      <a class="boton whatsapp" href="https://wa.me/5215512345678?text=Quiero%20comprar%20Balsamo%20Arbol%20de%20Te" target="_blank">WhatsApp</a>
+      <div class="paybutton-widget" to="ecash:qplm2jhzuteklx9naquzwfe97tx3h8eu4gyq385tw8" amount="50000" text="Pagar con XEC"></div>
     </div>
     <div class="producto">
       <img src="https://i.imgur.com/ejemplo2.jpg" alt="Bálsamo Lavanda">
       <h2>Bálsamo de Lavanda</h2>
       <p>Relajante, hidratante y con vitamina E. Aroma suave.</p>
       <a class="boton" href="https://xolosarmy.xyz/productos">Comprar en XolosArmy</a>
+      <a class="boton whatsapp" href="https://wa.me/5215512345678?text=Quiero%20comprar%20Balsamo%20Lavanda" target="_blank">WhatsApp</a>
+      <div class="paybutton-widget" to="ecash:qplm2jhzuteklx9naquzwfe97tx3h8eu4gyq385tw8" amount="50000" text="Pagar con XEC"></div>
     </div>
     <div class="producto">
       <img src="https://i.imgur.com/ejemplo3.jpg" alt="Bálsamo Limón">
       <h2>Bálsamo de Limón</h2>
       <p>Antibacterial, fresco y protector para la piel sensible.</p>
       <a class="boton" href="https://xolosarmy.xyz/productos">Comprar en XolosArmy</a>
+      <a class="boton whatsapp" href="https://wa.me/5215512345678?text=Quiero%20comprar%20Balsamo%20Limon" target="_blank">WhatsApp</a>
+      <div class="paybutton-widget" to="ecash:qplm2jhzuteklx9naquzwfe97tx3h8eu4gyq385tw8" amount="50000" text="Pagar con XEC"></div>
     </div>
     <div class="producto">
       <img src="https://i.imgur.com/ejemplo4.jpg" alt="Repelente de Limón">
       <h2>Repelente Natural</h2>
       <p>A base de limón. Protege contra pulgas, mosquitos y más.</p>
       <a class="boton" href="https://xolosarmy.xyz/productos">Comprar en XolosArmy</a>
+      <a class="boton whatsapp" href="https://wa.me/5215512345678?text=Quiero%20comprar%20Repelente%20Natural" target="_blank">WhatsApp</a>
+      <div class="paybutton-widget" to="ecash:qplm2jhzuteklx9naquzwfe97tx3h8eu4gyq385tw8" amount="50000" text="Pagar con XEC"></div>
     </div>
   </section>
 
   <footer>
     <p>&copy; 2025 Xolos Ramírez · Xoloitzcuintles con amor</p>
   </footer>
+  <script src="https://unpkg.com/@paybutton/paybutton/dist/paybutton.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add WhatsApp and paybutton styles
- show shipping information
- include WhatsApp link and paybutton below each product
- load paybutton script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851f96b5da08332b06b1cd38a598829