### PR TITLE
Add Radio Pública Twitter Space highlight in Business Network press section

### DIFF
--- a/business-network/index.html
+++ b/business-network/index.html
@@ -67,6 +67,22 @@
 
       <section class="section">
         <div class="container">
+          <div class="card space-radio-highlight" style="margin-bottom: 3rem; border: 1px solid rgba(29, 155, 240, 0.3); background: linear-gradient(145deg, rgba(10, 10, 10, 0.9) 0%, rgba(29, 155, 240, 0.05) 100%);">
+            <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 1rem;">
+              <span class="pulse-dot"></span>
+              <span style="text-transform: uppercase; font-size: 0.85em; font-weight: bold; color: #1d9bf0; letter-spacing: 0.1em;">Radio Pública: Última Emisión</span>
+            </div>
+            <h2 style="margin-top: 0;">Who Really Founded Bitcoin Cash?</h2>
+            <p class="muted">
+              Una conversación histórica y sin filtros con <strong>Cain</strong> sobre el origen de Bitcoin Cash, la evolución de eCash, y las figuras de Amaury Séchet y Freetrader. (Emisión en Inglés).
+            </p>
+            <div style="margin-top: 1.5rem;">
+              <a href="https://x.com/i/spaces/1YGNrZNQAObGw" target="_blank" rel="noopener noreferrer" class="btn btn-primary" style="background-color: #1d9bf0; border-color: #1d9bf0;">
+                Escuchar en xolosArmy Spaces ↗
+              </a>
+            </div>
+          </div>
+
           <h2 style="margin-bottom: 0.5rem;">Nuestra Voz</h2>
           <p class="muted" style="margin-bottom: 2rem;">Artículos, informes y ensayos clave para comprender la arquitectura filosófica de la civilización.</p>
 

--- a/css/layout.css
+++ b/css/layout.css
@@ -151,3 +151,38 @@
   letter-spacing: 0.03em;
   text-transform: uppercase;
 }
+
+/* Animación para la Radio Pública */
+.pulse-dot {
+  width: 10px;
+  height: 10px;
+  background-color: #1d9bf0;
+  border-radius: 50%;
+  display: inline-block;
+  box-shadow: 0 0 0 0 rgba(29, 155, 240, 0.7);
+  animation: pulse-blue 2s infinite;
+}
+
+@keyframes pulse-blue {
+  0% {
+    transform: scale(0.95);
+    box-shadow: 0 0 0 0 rgba(29, 155, 240, 0.7);
+  }
+  70% {
+    transform: scale(1);
+    box-shadow: 0 0 0 10px rgba(29, 155, 240, 0);
+  }
+  100% {
+    transform: scale(0.95);
+    box-shadow: 0 0 0 0 rgba(29, 155, 240, 0);
+  }
+}
+
+.space-radio-highlight {
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.space-radio-highlight:hover {
+  transform: translateY(-5px);
+  border-color: #1d9bf0 !important;
+}


### PR DESCRIPTION
### Motivation
- Surface the latest Twitter Space as a prominent "Radio Pública" highlight so the newest media emission appears immediately above the `Nuestra Voz` article grid.
- Provide a reusable, visually distinct card with a CTA that matches the X/Twitter brand and signals a live/recorded broadcast.

### Description
- Inserted a highlight card block before the `Nuestra Voz` header in `business-network/index.html` containing title, description, and the Space link `https://x.com/i/spaces/1YGNrZNQAObGw` with a CTA button.
- Added broadcast styling to `css/layout.css`, including the `.pulse-dot` animated indicator, `@keyframes pulse-blue`, and the `.space-radio-highlight` hover interaction.
- Kept the existing `Nuestra Voz` heading and article grid unchanged so the highlight appears as the primary element in the section.

### Testing
- Verified the new HTML block and selectors are present using `rg -n "Radio Pública: Última Emisión|pulse-dot|space-radio-highlight"` which returned the inserted lines successfully.
- Inspected file fragments with `sed -n`/`nl -ba` to confirm the exact block was added to `business-network/index.html` and the CSS rules were appended to `css/layout.css`.
- Confirmed `business-network/index.html` already references `css/layout.css` via `rg -n "css/layout.css|css/base.css" business-network/index.html` so styles will be applied; the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4b445ad083328588973141298b8c)