### PR TITLE
Agregar snippet de Google Analytics (gtag) a index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Civilización Tonalli | xolosArmy Network State</title>
     <meta name="description" content="Una capa humana sobre infraestructura digital. Descubre el Portal Constitucional de la Civilización Tonalli." />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YTZMJ41WMY"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-YTZMJ41WMY');
+    </script>
     <link rel="stylesheet" href="/css/base.css" />
     <link rel="stylesheet" href="/css/layout.css" />
     <link rel="stylesheet" href="/css/cinematic.css" />


### PR DESCRIPTION
### Motivation
- Habilitar el seguimiento de visitantes en la página principal agregando el snippet oficial de Google Analytics con el ID de medición provisto (`G-YTZMJ41WMY`).

### Description
- Se insertó el script asíncrono `https://www.googletagmanager.com/gtag/js?id=G-YTZMJ41WMY` y el bloque de inicialización `gtag('config', 'G-YTZMJ41WMY')` en `index.html` inmediatamente después de la meta `description` y antes de los enlaces CSS en el `<head>`.

### Testing
- Verifiqué que el snippet aparece en la ubicación prevista mediante `git diff -- index.html` y mediante inspección del archivo con `nl -ba index.html | sed -n '1,35p'`, ambos devolvieron la presencia correcta del bloque de código.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8344f3988332b06d965070b5baf0)