### PR TITLE
Actualizar enlaces de WhatsApp en productos-xoloitzcuintle

### DIFF
--- a/productos-xoloitzcuintle/index.html
+++ b/productos-xoloitzcuintle/index.html
@@ -1534,7 +1534,7 @@
           Abrir RMZWallet Tonalli
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>¿Cómo pagar con Tonalli?</button>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Bálsamo+Arbol+de+té"
+        <a href="https://wa.me/qr/LNO2OMMH2ZKWF1?text=Hola%2C+quiero+comprar+el+Bálsamo+Arbol+de+té"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
            data-ga-event="whatsapp_lead"
            data-item="Ungüento Solar del Guardián Xólotl"
@@ -1575,7 +1575,7 @@
           Abrir RMZWallet Tonalli
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>¿Cómo pagar con Tonalli?</button>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Bálsamo+Lavanda"
+        <a href="https://wa.me/qr/LNO2OMMH2ZKWF1?text=Hola%2C+quiero+comprar+el+Bálsamo+Lavanda"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Néctar Onírico de Tlazōlteōtl"
            aria-label="Abrir WhatsApp para comprar el Néctar Onírico de Tlazōlteōtl mediante transferencia bancaria">
@@ -1615,7 +1615,7 @@
           Abrir RMZWallet Tonalli
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>¿Cómo pagar con Tonalli?</button>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Bálsamo+Limón"
+        <a href="https://wa.me/qr/LNO2OMMH2ZKWF1?text=Hola%2C+quiero+comprar+el+Bálsamo+Limón"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Esencia Citlalinahuatl del Amanecer"
            aria-label="Abrir WhatsApp para comprar la Esencia Citlalinahuatl del Amanecer mediante transferencia bancaria">
@@ -1655,7 +1655,7 @@
           Abrir RMZWallet Tonalli
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>¿Cómo pagar con Tonalli?</button>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Repelente+Limón"
+        <a href="https://wa.me/qr/LNO2OMMH2ZKWF1?text=Hola%2C+quiero+comprar+el+Repelente+Limón"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Escudo de Bruma de Quetzalcóatl"
            aria-label="Abrir WhatsApp para comprar el Escudo de Bruma de Quetzalcóatl mediante transferencia bancaria">
@@ -1700,7 +1700,7 @@
           Abrir RMZWallet Tonalli
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>¿Cómo pagar con Tonalli?</button>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+jabon+exfoliante"
+        <a href="https://wa.me/qr/LNO2OMMH2ZKWF1?text=Hola%2C+quiero+comprar+jabon+exfoliante"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Dúo Ritual de Espuma del Mictlán"
            aria-label="Abrir WhatsApp para comprar el Dúo Ritual de Espuma del Mictlán mediante transferencia bancaria">
@@ -1746,7 +1746,7 @@
           Abrir RMZWallet Tonalli
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>¿Cómo pagar con Tonalli?</button>
-        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Paquete+Bienestar+Integral+Xoloitzcuintle"
+        <a href="https://wa.me/qr/LNO2OMMH2ZKWF1?text=Hola%2C+quiero+comprar+el+Paquete+Bienestar+Integral+Xoloitzcuintle"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Paquete Bienestar Integral Xoloitzcuintle"
            aria-label="Abrir WhatsApp para comprar el Paquete Bienestar Integral Xoloitzcuintle mediante transferencia bancaria">
@@ -1796,7 +1796,7 @@
 
       <a
         class="sticky-buy__action sticky-buy__action--whatsapp"
-        href="https://wa.me/message/435RTKGJLTX2J1"
+        href="https://wa.me/qr/LNO2OMMH2ZKWF1"
         target="_blank"
         rel="noopener noreferrer"
         data-ga-event="whatsapp_lead"


### PR DESCRIPTION
### Motivation
- Actualizar el enlace base de WhatsApp usado en los botones de compra para apuntar al nuevo QR en lugar del enlace anterior, manteniendo los textos prellenados por producto.

### Description
- Reemplacé `https://wa.me/message/435RTKGJLTX2J1` por `https://wa.me/qr/LNO2OMMH2ZKWF1` en `productos-xoloitzcuintle/index.html`, afectando 7 ocurrencias (6 botones de producto + 1 `sticky-buy`).

### Testing
- Ejecuté búsquedas con `rg -n` para verificar que la URL antigua ya no aparece y que hay exactamente 7 ocurrencias de la nueva URL, ambas comprobaciones exitosas.
- Confirmé los cambios con `git diff` y realicé el `git commit` con el mensaje `Actualizar enlaces de WhatsApp en productos xoloitzcuintle`, operación exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8e988f388332b963201d75e74d8a)