### PR TITLE
Actualizar enlaces de WhatsApp en productos-xoloitzcuintle

### DIFF
--- a/productos-xoloitzcuintle/index.html
+++ b/productos-xoloitzcuintle/index.html
@@ -1616,7 +1616,7 @@
           Abrir wallet Tonalli (paso 2)
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
-        <a href="https://wa.me/qr/LNO2OMMH2ZKWF1?text=Hola%2C+quiero+comprar+el+Bálsamo+Arbol+de+té"
+        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Bálsamo+Arbol+de+té"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer"
            data-ga-event="whatsapp_lead"
            data-item="Ungüento Solar del Guardián Xólotl"
@@ -1660,7 +1660,7 @@
           Abrir wallet Tonalli (paso 2)
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
-        <a href="https://wa.me/qr/LNO2OMMH2ZKWF1?text=Hola%2C+quiero+comprar+el+Bálsamo+Lavanda"
+        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Bálsamo+Lavanda"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Néctar Onírico de Tlazōlteōtl"
            aria-label="Abrir WhatsApp para comprar el Néctar Onírico de Tlazōlteōtl mediante transferencia bancaria">
@@ -1703,7 +1703,7 @@
           Abrir wallet Tonalli (paso 2)
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
-        <a href="https://wa.me/qr/LNO2OMMH2ZKWF1?text=Hola%2C+quiero+comprar+el+Bálsamo+Limón"
+        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Bálsamo+Limón"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Esencia Citlalinahuatl del Amanecer"
            aria-label="Abrir WhatsApp para comprar la Esencia Citlalinahuatl del Amanecer mediante transferencia bancaria">
@@ -1746,7 +1746,7 @@
           Abrir wallet Tonalli (paso 2)
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
-        <a href="https://wa.me/qr/LNO2OMMH2ZKWF1?text=Hola%2C+quiero+comprar+el+Repelente+Limón"
+        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Repelente+Limón"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Escudo de Bruma de Quetzalcóatl"
            aria-label="Abrir WhatsApp para comprar el Escudo de Bruma de Quetzalcóatl mediante transferencia bancaria">
@@ -1794,7 +1794,7 @@
           Abrir wallet Tonalli (paso 2)
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
-        <a href="https://wa.me/qr/LNO2OMMH2ZKWF1?text=Hola%2C+quiero+comprar+jabon+exfoliante"
+        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+jabon+exfoliante"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Dúo Ritual de Espuma del Mictlán"
            aria-label="Abrir WhatsApp para comprar el Dúo Ritual de Espuma del Mictlán mediante transferencia bancaria">
@@ -1843,7 +1843,7 @@
           Abrir wallet Tonalli (paso 2)
         </a>
         <button class="tonalli-guide" type="button" data-open-tonalli-modal>Guía Tonalli (paso a paso)</button>
-        <a href="https://wa.me/qr/LNO2OMMH2ZKWF1?text=Hola%2C+quiero+comprar+el+Paquete+Bienestar+Integral+Xoloitzcuintle"
+        <a href="https://wa.me/message/435RTKGJLTX2J1?text=Hola%2C+quiero+comprar+el+Paquete+Bienestar+Integral+Xoloitzcuintle"
            class="whatsapp-buy" target="_blank" rel="noopener noreferrer" data-ga-event="whatsapp_lead"
            data-item="Paquete Bienestar Integral Xoloitzcuintle"
            aria-label="Abrir WhatsApp para comprar el Paquete Bienestar Integral Xoloitzcuintle mediante transferencia bancaria">
@@ -1894,7 +1894,7 @@
 
       <a
         class="sticky-buy__action sticky-buy__action--whatsapp"
-        href="https://wa.me/qr/LNO2OMMH2ZKWF1"
+        href="https://wa.me/message/435RTKGJLTX2J1"
         target="_blank"
         rel="noopener noreferrer"
         data-ga-event="whatsapp_lead"


### PR DESCRIPTION
### Motivation
- Sustituir el enlace de WhatsApp basado en QR por el nuevo `https://wa.me/message/435RTKGJLTX2J1` en las llamadas a la acción de compra para apuntar al número/destino correcto.

### Description
- Reemplacé `https://wa.me/qr/LNO2OMMH2ZKWF1` por `https://wa.me/message/435RTKGJLTX2J1` en `productos-xoloitzcuintle/index.html`, afectando 7 enlaces entre botones de producto y el botón sticky de WhatsApp.
- Se preservaron los parámetros prellenados `?text=...` y los atributos existentes como `data-ga-event`, `data-item` y `aria-label` en cada enlace.
- No se modificaron otros archivos ni lógica adicional fuera de las URLs en la página mencionada.

### Testing
- Ejecuté un script de reemplazo que reportó `replaced 7`, confirmando 7 ocurrencias actualizadas; resultado: exitoso.
- Verifiqué la presencia de las nuevas URLs con `rg -n "wa\.me/message/435RTKGJLTX2J1" productos-xoloitzcuintle/index.html`; resultado: exitoso.
- Inspeccioné el diff del archivo modificado y confirmé 7 inserciones y 7 eliminaciones en `productos-xoloitzcuintle/index.html`; resultado: exitoso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3b0e66288332b34363a8a9cf4f4b)