### PR TITLE
Actualizar URLs y textos alt de imágenes en productos Xoloitzcuintle

### DIFF
--- a/productos-xoloitzcuintle/index.html
+++ b/productos-xoloitzcuintle/index.html
@@ -1576,10 +1576,10 @@
     <div class="card animate-on-scroll" data-sku="xolo-unguento" data-category="balsamo">
       <div class="product-media">
         <img
-          src="https://i.imgur.com/J8mc04B.png"
+          src="https://i.imgur.com/9leXEhh.png"
           loading="lazy"
           decoding="async"
-          alt="Ungüento Solar del Guardián Xólotl – bálsamo en frasco ámbar esmerilado con tapa blanca."
+          alt="Ungüento Solar del Guardián Xólotl – bálsamo de árbol de té."
         />
       </div>
       <div class="card-body">
@@ -1620,10 +1620,10 @@
     <div class="card animate-on-scroll" data-sku="xolo-nectar" data-category="balsamo">
       <div class="product-media">
         <img
-          src="https://i.imgur.com/hosQNaj.png"
+          src="https://i.imgur.com/tvIa6wv.png"
           loading="lazy"
           decoding="async"
-          alt="Néctar Onírico de Tlazōlteōtl – frasco con esencia de lavanda."
+          alt="Néctar Onírico de Tlazōlteōtl – bálsamo de lavanda."
         />
       </div>
       <div class="card-body">
@@ -1663,10 +1663,10 @@
     <div class="card animate-on-scroll" data-sku="xolo-amanecer" data-category="balsamo">
       <div class="product-media">
         <img
-          src="https://i.imgur.com/PloLYl4.png"
+          src="https://i.imgur.com/s3XazHr.png"
           loading="lazy"
           decoding="async"
-          alt="Esencia Citlalinahuatl del Amanecer – frasco con aceite esencial de limón."
+          alt="Esencia Citlalinahuatl del Amanecer – bálsamo de limón."
         />
       </div>
       <div class="card-body">
@@ -1706,10 +1706,10 @@
     <div class="card animate-on-scroll" data-sku="xolo-escudo" data-category="balsamo">
       <div class="product-media">
         <img
-          src="https://i.imgur.com/EQqSZqA.jpeg"
+          src="https://i.imgur.com/epnPlaq.png"
           loading="lazy"
           decoding="async"
-          alt="Escudo de Bruma de Quetzalcóatl — spray repelente XolosArmy Naturals"
+          alt="Escudo de Bruma de Quetzalcóatl — spray repelente."
         />
       </div>
       <div class="card-body">
@@ -1749,10 +1749,10 @@
     <div class="card animate-on-scroll" data-sku="xolo-duo" data-category="jabon">
       <div class="product-media">
         <img
-          src="https://i.imgur.com/b9GOJK6.jpeg"
+          src="https://i.imgur.com/fz3cMhC.png"
           loading="lazy"
           decoding="async"
-          alt="Jabón artesanal XolosArmy Naturals — dúo ritual de espuma"
+          alt="Jabón artesanal XolosArmy Naturals — dúo ritual de espuma."
         />
       </div>
       <div class="card-body">
@@ -1798,10 +1798,10 @@
     <div class="card animate-on-scroll" data-sku="xolo-bienestar" data-category="kit">
       <div class="product-media">
         <img
-          src="https://i.imgur.com/dAHwm7a.png"
+          src="https://i.imgur.com/gFMTtXu.png"
           loading="lazy"
           decoding="async"
-          alt="Paquete Bienestar Integral Xoloitzcuintle — 3 bálsamos, 2 jabones y spray"
+          alt="Paquete Bienestar Integral Xoloitzcuintle — kit completo."
         />
       </div>
       <div class="card-body">


### PR DESCRIPTION
### Motivation
- Actualizar las imágenes públicas de los productos para usar las nuevas URLs de Imgur y mejorar las descripciones accesibles.
- Mantener las optimizaciones de carga ya existentes (`loading="lazy"` y `decoding="async"`) sin cambiar la estructura ni la lógica de la página.

### Description
- Se reemplazaron los `src` de las 6 imágenes de la cuadrícula de productos en `productos-xoloitzcuintle/index.html` para los SKUs `xolo-unguento`, `xolo-nectar`, `xolo-amanecer`, `xolo-escudo`, `xolo-duo` y `xolo-bienestar` con las nuevas URLs de Imgur.
- Se actualizaron los atributos `alt` correspondientes para que coincidan con las descripciones solicitadas.
- No se tocaron otros elementos de la página ni la lógica JavaScript; los atributos `loading` y `decoding` se conservaron.

### Testing
- Ejecuté una búsqueda de confirmación con `rg` para verificar que las nuevas cadenas de Imgur aparecen en `productos-xoloitzcuintle/index.html`, y la búsqueda devolvió las coincidencias esperadas.
- Verifiqué el estado de git con `git status --short` y confirmé que el archivo modificado fue commiteado con el mensaje `Actualizar imágenes de productos Xoloitzcuintle`.
- Todas las comprobaciones automáticas realizadas (búsqueda y estado de git) resultaron exitosas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee88a023f08332b8c4c3f8073a78d3)