### PR TITLE
Add Teyolia navigation and CTA to PoW article

### DIFF
--- a/blog/pow-surface-attacks.html
+++ b/blog/pow-surface-attacks.html
@@ -274,6 +274,64 @@
       font-weight: 850;
     }
 
+    /* New Navigation Header */
+    .nav-top {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 24px;
+      padding: 0 4px;
+    }
+
+    .nav-top a {
+      text-decoration: none;
+      font-size: 0.9rem;
+      font-weight: 700;
+      transition: all 0.2s ease;
+    }
+
+    .back-home {
+      color: var(--muted);
+    }
+
+    .back-home:hover {
+      color: var(--blue);
+    }
+
+    .support-pill {
+      background: rgba(0, 217, 255, 0.1);
+      border: 1px solid var(--blue);
+      color: var(--blue) !important;
+      padding: 6px 14px;
+      border-radius: 100px;
+      letter-spacing: 0.02em;
+    }
+
+    .support-pill:hover {
+      background: var(--blue);
+      color: #050505 !important;
+      box-shadow: 0 0 15px var(--shadow-blue);
+    }
+
+    .cta-button {
+      display: inline-block;
+      background: linear-gradient(135deg, var(--blue), var(--green));
+      color: #050505;
+      text-decoration: none;
+      font-size: 1rem;
+      font-weight: 850;
+      padding: 14px 24px;
+      border-radius: 999px;
+      letter-spacing: 0.02em;
+      box-shadow: 0 0 22px var(--shadow-blue);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .cta-button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 0 28px var(--shadow-green);
+    }
+
     @media (max-width: 640px) {
       .page {
         padding: 32px 14px 56px;
@@ -307,6 +365,11 @@
 
 <body>
   <main class="page">
+
+    <nav class="nav-top">
+      <a href="/" class="back-home">← xolosArmy Home</a>
+      <a href="https://www.teyolia.cash/campaigns/campaign-1775831790436" class="support-pill" target="_blank" rel="noopener noreferrer">Support Teyolia</a>
+    </nav>
 
     <header class="hero">
       <div class="kicker">xolosArmy Network Opinion Column</div>
@@ -544,6 +607,12 @@
       <div class="quote">
         In calm markets, native liquidity is useful. <span>In hostile markets, it can be existential.</span>
       </div>
+
+      <p style="text-align: center; margin-top: 3rem;">
+        <a href="https://www.teyolia.cash/campaigns/campaign-1775831790436" class="cta-button" target="_blank" rel="noopener noreferrer">
+          Fund Sovereign Liquidity Infrastructure
+        </a>
+      </p>
 
       <p class="disclaimer">
         This column is an opinion piece by xolosArmy Network. It does not accuse any specific person, company, exchange or project of malicious conduct. Its purpose is to analyze general strategic risks around proof-of-work forks, centralized exchange dependency, brand confusion and the potential role of native cross-chain liquidity as resilience infrastructure.


### PR DESCRIPTION
### Motivation
- Improve reader navigation and site legitimacy by adding a minimal top navigation linking back to the site home and surfacing the Teyolia campaign as a primary conversion target. 
- Provide a direct conversion path for readers convinced by the article by adding a prominent CTA before the disclaimer.

### Description
- Added new CSS rules for a top navigation and support styles including `.nav-top`, `.back-home`, `.support-pill` and a reusable `.cta-button` to `blog/pow-surface-attacks.html`. 
- Inserted a minimal navigation block (link to `/` and a Teyolia pill link) immediately inside `<main class="page">` before the hero header in `blog/pow-surface-attacks.html`. 
- Inserted a final CTA block linking to the Teyolia campaign before the disclaimer paragraph in `blog/pow-surface-attacks.html`.

### Testing
- Ran `git diff --check` and found no whitespace or diff-check issues. 
- Verified the modified HTML parses with Python's `HTMLParser` using `python3` which reported `HTML parsed successfully`. 
- Captured a page render with Playwright using `npx playwright screenshot` and produced a screenshot at `/tmp/pow-surface-attacks-nav.png` to visually confirm the navigation and CTA rendering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa8f4b2818833287d645081ea7bc39)