### PR TITLE
Add RMZ NFT inscription section

### DIFF
--- a/assets/arte-ceremonial-rmz.svg
+++ b/assets/arte-ceremonial-rmz.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 900" role="img" aria-labelledby="title desc">
+  <title id="title">Arte Ceremonial Evangelio RMZ</title>
+  <desc id="desc">Composición ceremonial con un Xolo de obsidiana, fuego dorado y símbolos de linaje RMZ.</desc>
+  <defs>
+    <radialGradient id="ember" cx="50%" cy="44%" r="58%">
+      <stop offset="0%" stop-color="#ffd86b" stop-opacity="0.95"/>
+      <stop offset="38%" stop-color="#e63946" stop-opacity="0.55"/>
+      <stop offset="72%" stop-color="#28110d" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#060606"/>
+    </radialGradient>
+    <linearGradient id="obsidian" x1="18%" y1="12%" x2="82%" y2="88%">
+      <stop offset="0%" stop-color="#24242c"/>
+      <stop offset="48%" stop-color="#070709"/>
+      <stop offset="100%" stop-color="#151018"/>
+    </linearGradient>
+    <linearGradient id="gold" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fff1a6"/>
+      <stop offset="50%" stop-color="#ffd700"/>
+      <stop offset="100%" stop-color="#b76519"/>
+    </linearGradient>
+    <filter id="glow" x="-35%" y="-35%" width="170%" height="170%">
+      <feGaussianBlur stdDeviation="11" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 1  0 0.78 0 0 0.52  0 0 0.25 0 0.05  0 0 0 0.9 0" result="goldGlow"/>
+      <feMerge>
+        <feMergeNode in="goldGlow"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <pattern id="glyphs" width="96" height="96" patternUnits="userSpaceOnUse">
+      <path d="M16 48h24v-24h16v48h24" fill="none" stroke="#ffd700" stroke-opacity="0.12" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+      <circle cx="70" cy="24" r="5" fill="#e63946" fill-opacity="0.16"/>
+    </pattern>
+  </defs>
+
+  <rect width="900" height="900" fill="#060606"/>
+  <rect width="900" height="900" fill="url(#ember)"/>
+  <rect width="900" height="900" fill="url(#glyphs)"/>
+
+  <g opacity="0.56" filter="url(#glow)">
+    <circle cx="450" cy="450" r="304" fill="none" stroke="url(#gold)" stroke-width="8"/>
+    <circle cx="450" cy="450" r="240" fill="none" stroke="#e63946" stroke-width="3" stroke-dasharray="18 18"/>
+    <path d="M450 103l41 126 132-1-107 77 42 126-108-78-107 78 41-126-107-77 132 1z" fill="none" stroke="url(#gold)" stroke-width="6" opacity="0.7"/>
+  </g>
+
+  <g transform="translate(127 208)">
+    <path d="M215 333c-23-34-36-74-31-120 8-72 58-135 133-161 67-24 144-12 203 31 26 19 48 43 64 72l55 2c15 0 25 15 19 29l-22 50c-7 15-23 23-39 19l-38-10c-14 37-41 69-76 92l30 141c4 19-10 37-29 37h-33l-28-126c-17 4-35 6-53 5l-17 91c-4 17-18 30-36 30h-31l15-133c-24-11-46-27-65-49l-83 34c-23 10-48-8-47-33l1-25z" fill="url(#obsidian)" stroke="#ffd700" stroke-width="8" stroke-linejoin="round"/>
+    <path d="M546 128l48-74 15 102" fill="url(#obsidian)" stroke="#ffd700" stroke-width="8" stroke-linejoin="round"/>
+    <path d="M625 159l63-42-24 77" fill="url(#obsidian)" stroke="#ffd700" stroke-width="8" stroke-linejoin="round"/>
+    <circle cx="562" cy="168" r="13" fill="#ffd700"/>
+    <path d="M223 329c49 36 110 51 172 40 76-13 137-64 166-131" fill="none" stroke="#fce38a" stroke-opacity="0.4" stroke-width="5" stroke-linecap="round"/>
+  </g>
+
+  <g text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" filter="url(#glow)">
+    <text x="450" y="724" fill="#ffd700" font-size="54" font-weight="700" letter-spacing="7">RMZ</text>
+    <text x="450" y="779" fill="#fce38a" font-size="24" letter-spacing="5">SELLO DEL PACTO #001</text>
+  </g>
+</svg>

--- a/blog/xoloitzcuintli-rmz-gospel.html
+++ b/blog/xoloitzcuintli-rmz-gospel.html
@@ -53,6 +53,123 @@
       color: #fce38a;
     }
 
+    .nft-inscription {
+      margin-top: 3em;
+      padding-top: 3em;
+      border-top: 1px solid rgba(255, 215, 0, 0.28);
+    }
+
+    .nft-card {
+      display: grid;
+      grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.2fr);
+      gap: 1.5em;
+      overflow: hidden;
+      border: 1px solid rgba(252, 227, 138, 0.35);
+      border-radius: 18px;
+      background:
+        radial-gradient(circle at top left, rgba(230, 57, 70, 0.26), transparent 34%),
+        linear-gradient(145deg, rgba(27, 22, 18, 0.96), rgba(8, 8, 8, 0.98));
+      box-shadow: 0 0 36px rgba(255, 215, 0, 0.09);
+    }
+
+    .nft-visual {
+      position: relative;
+      min-height: 100%;
+      background: #0d0d0d;
+      isolation: isolate;
+    }
+
+    .nft-visual img {
+      width: 100%;
+      height: 100%;
+      min-height: 280px;
+      display: block;
+      object-fit: cover;
+      filter: saturate(1.12) contrast(1.08);
+    }
+
+    .scanline {
+      position: absolute;
+      inset: 0;
+      z-index: 1;
+      pointer-events: none;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.08) 0,
+        rgba(255, 255, 255, 0.08) 1px,
+        transparent 1px,
+        transparent 7px
+      );
+      mix-blend-mode: overlay;
+      opacity: 0.34;
+    }
+
+    .nft-info {
+      padding: 1.6em;
+    }
+
+    .label {
+      display: inline-block;
+      margin-bottom: 0.7em;
+      color: #fce38a;
+      font-size: 0.75em;
+      font-weight: bold;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+    }
+
+    .nft-info h3 {
+      margin: 0 0 0.7em;
+      color: #ffd700;
+      font-size: 1.55em;
+      line-height: 1.2;
+    }
+
+    .tx-box {
+      margin: 1.4em 0;
+      padding: 1em;
+      border: 1px solid rgba(255, 215, 0, 0.24);
+      border-radius: 12px;
+      background: rgba(0, 0, 0, 0.38);
+    }
+
+    .tx-label {
+      display: block;
+      margin-bottom: 0.45em;
+      color: #aaa;
+      font-size: 0.82em;
+      text-transform: uppercase;
+      letter-spacing: 0.11em;
+    }
+
+    .tx-hash {
+      display: block;
+      color: #fce38a;
+      font-family: 'Courier New', monospace;
+      font-size: 0.82em;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+
+    .btn-explorer {
+      display: inline-block;
+      padding: 0.85em 1.15em;
+      border: 1px solid rgba(252, 227, 138, 0.72);
+      border-radius: 999px;
+      background: linear-gradient(135deg, #ffd700, #e63946);
+      color: #111;
+      font-weight: bold;
+      text-decoration: none;
+      box-shadow: 0 10px 24px rgba(230, 57, 70, 0.2);
+      transition: transform 180ms ease, box-shadow 180ms ease;
+    }
+
+    .btn-explorer:hover,
+    .btn-explorer:focus {
+      transform: translateY(-2px);
+      box-shadow: 0 14px 30px rgba(255, 215, 0, 0.22);
+    }
+
     @media (max-width: 600px) {
       body {
         padding: 1em;
@@ -60,6 +177,14 @@
 
       .container {
         padding: 1.5em;
+      }
+
+      .nft-card {
+        grid-template-columns: 1fr;
+      }
+
+      .nft-info {
+        padding: 1.25em;
       }
     }
   </style>
@@ -88,6 +213,30 @@
       Amen Mictlán.<br>
       Amen Memory.
     </div>
+
+    <section class="nft-inscription" aria-labelledby="nft-title">
+      <div class="nft-card">
+        <div class="nft-visual">
+          <img src="../assets/arte-ceremonial-rmz.svg" alt="Arte Ceremonial Evangelio RMZ">
+          <div class="scanline"></div>
+        </div>
+        <div class="nft-info">
+          <span class="label">Inscripción en Blockchain</span>
+          <h3 id="nft-title">Sello del Pacto RMZ #001</h3>
+          <p>Este Evangelio ha sido minteado como un activo soberano. Representa la primera piedra de la Red y el compromiso de lealtad absoluta al código abierto.</p>
+
+          <div class="tx-box">
+            <span class="tx-label">Transacción ID:</span>
+            <code class="tx-hash">17c807b364516916efbcfe64eac15b212935cce9e96aa58596bfbacfdba0d7c4</code>
+          </div>
+
+          <a href="https://explorer.xolosarmy.xyz/tx/17c807b364516916efbcfe64eac15b212935cce9e96aa58596bfbacfdba0d7c4"
+             target="_blank" rel="noopener noreferrer" class="btn-explorer">
+            Verificar en el Explorer
+          </a>
+        </div>
+      </div>
+    </section>
   </div>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Embed a verifiable NFT inscription into the RMZ Gospel page so the narrative is tied to on-chain proof and explorers can verify the mint. 
- Provide an attractive, on-brand visual and UI for readers to inspect the transaction and recognize the commemorative `Sello del Pacto RMZ #001` token. 
- Ensure the new content is responsive and accessible so it works across devices and can be discovered by users following the text.

### Description
- Updated `blog/xoloitzcuintli-rmz-gospel.html` to include new styles for `.nft-inscription`/`.nft-card` and to append a dedicated NFT card section with image, TX hash display, and an explorer verification button. 
- Added new SVG artwork at `assets/arte-ceremonial-rmz.svg` and referenced it from the card to avoid missing assets and to provide a ceremonial visual treatment. 
- The explorer link opens in a new tab and includes `rel="noopener noreferrer"`, the section uses `aria-labelledby` for accessibility, and the layout is responsive (grid → single column on small screens).

### Testing
- Ran a basic HTML parse using Python (`html.parser`) on `blog/xoloitzcuintli-rmz-gospel.html`, which completed successfully. 
- Parsed the new SVG with Python's `xml.etree.ElementTree` (`ET.parse`) for syntax validity, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a075b0f832083329f80911fa1dc5128)