### PR TITLE
Agregar mitograma y estilos a artículo Teposxolotlcalli

### DIFF
--- a/blog/nahuatl-y-xoloitzcuintle-codice-vivo-xoloitzcuintle.html
+++ b/blog/nahuatl-y-xoloitzcuintle-codice-vivo-xoloitzcuintle.html
@@ -185,6 +185,25 @@
       font-family: Arial, sans-serif;
     }
 
+    .mitograma-img {
+      width: 100%;
+      height: auto;
+      border-radius: 22px;
+      border: 1px solid var(--line);
+      margin: 36px 0;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5), 0 0 20px rgba(214, 168, 79, 0.1);
+      display: block;
+    }
+
+    .mitograma-caption {
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.95rem;
+      margin-top: -20px;
+      margin-bottom: 36px;
+      font-style: italic;
+    }
+
     @media (max-width: 720px) {
       .hero,
       .content {
@@ -271,6 +290,9 @@
         vasijas o relieves que narraban episodios míticos. Una escena podía contener una historia completa:
         el origen de un pueblo, el tránsito de un alma, la aparición de una deidad o la fundación de una comunidad.
       </p>
+
+      <img src="https://i.imgur.com/bVuXCn9.jpeg" alt="Mitograma Teposxolotlcalli: Origen, Peregrinación, Guía, Fundación y Memoria" class="mitograma-img" loading="lazy" />
+      <div class="mitograma-caption">El xoloitzcuintle como guía en el códice vivo de Teposxolotlcalli.</div>
 
       <p>
         El mitograma no se mira como decoración. Se lee como memoria. Cada figura, postura,


### PR DESCRIPTION
### Motivation
- Integrar el mitograma en la sección 3 del artículo para reforzar la narrativa visual y mantener la estética oscura y reverencial de Teposxolotlcalli.

### Description
- Añadida la clase CSS `mitograma-img` con `border-radius`, `box-shadow`, `border` y `width: 100%` dentro del bloque `<style>` antes de `@media (max-width: 720px)` en `blog/nahuatl-y-xoloitzcuintle-codice-vivo-xoloitzcuintle.html`.
- Añadida la clase CSS `mitograma-caption` para el pie de foto con texto centrado, color atenuado e itálica en el mismo archivo.
- Insertada la etiqueta de imagen `<img src="https://i.imgur.com/bVuXCn9.jpeg" class="mitograma-img" loading="lazy" />` y su `div` de pie de foto inmediatamente después del párrafo introductorio de la sección 3 (`3. Mitogramas: imágenes que cuentan el mito`).

### Testing
- Ejecutado un parseo HTML con `python3 - <<'PY' ... HTMLParser ... PY` y la verificación completó correctamente (éxito).
- Ejecutado `git diff --check` para detectar problemas de whitespace y no se encontraron errores (éxito).
- Generada una captura de la sección con Playwright y la imagen se escribió en `/tmp/xolos_screenshots/mitograma-section.png` (archivo generado con éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e3a8775f8833286daaf3a5504b3f3)